### PR TITLE
Add CSV fetch error handling and tests

### DIFF
--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -1,4 +1,4 @@
-const QuantumDashboard = require('../app');
+const { QuantumDashboard } = require('../app');
 
 beforeEach(() => {
   QuantumDashboard.prototype.init = jest.fn();

--- a/tests/fetchCSV.test.js
+++ b/tests/fetchCSV.test.js
@@ -1,0 +1,21 @@
+const { QuantumDashboard, CSVFetchError } = require('../app');
+
+describe('fetchCSV error handling', () => {
+  beforeEach(() => {
+    QuantumDashboard.prototype.init = jest.fn();
+  });
+
+  test('throws CSVFetchError on network failure', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('network down')));
+    const dash = new QuantumDashboard();
+    await expect(dash.fetchCSV('bad.csv')).rejects.toThrow(CSVFetchError);
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  test('throws CSVFetchError on non-OK status', async () => {
+    global.fetch = jest.fn(() => Promise.resolve({ ok: false, status: 500, statusText: 'Server Error' }));
+    const dash = new QuantumDashboard();
+    await expect(dash.fetchCSV('bad.csv')).rejects.toThrow(CSVFetchError);
+    expect(fetch).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `CSVFetchError` class and export it
- wrap `fetchCSV` network logic in try/catch and throw `CSVFetchError`
- update module exports and tests to use named exports
- add unit tests for fetch errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887c2bda6c8832297e6db66a5491a86