### PR TITLE
Add debounced resize handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -116,9 +116,10 @@ class QuantumDashboard {
             panel.addEventListener('mouseleave', (e) => this.handlePanelLeave(e));
         });
 
-        // Responsive design handlers
-        window.addEventListener('resize', () => this.handleResize());
-        window.addEventListener('orientationchange', () => this.handleOrientationChange());
+        // Responsive design handlers with throttling
+        this.debouncedResize = this.debounce(() => this.handleResize(), 100);
+        window.addEventListener('resize', this.debouncedResize);
+        window.addEventListener('orientationchange', this.debouncedResize);
     }
 
     startRealTimeUpdates() {
@@ -1140,7 +1141,7 @@ class QuantumDashboard {
     scrollToPanelMobile(panelType) {
         const panelMap = {
             'market': '.panel-market-growth',
-            'geographic': '.panel-geographic', 
+            'geographic': '.panel-geographic',
             'investment': '.panel-investment',
             'companies': '.panel-companies'
         };
@@ -1154,6 +1155,20 @@ class QuantumDashboard {
         }
     }
 
+    /**
+     * Returns a debounced version of the supplied function.
+     * @param {Function} fn - Function to debounce
+     * @param {number} delay - Delay in ms
+     * @returns {Function}
+     */
+    debounce(fn, delay) {
+        let timer;
+        return (...args) => {
+            clearTimeout(timer);
+            timer = setTimeout(() => fn(...args), delay);
+        };
+    }
+
     handleResize() {
         const mobileNav = document.querySelector('.mobile-nav');
         if (window.innerWidth <= 1024) {
@@ -1163,11 +1178,7 @@ class QuantumDashboard {
         }
     }
 
-    handleOrientationChange() {
-        setTimeout(() => {
-            this.handleResize();
-        }, 100);
-    }
+
 
     // Analytics and performance
     logInteraction(type, value) {

--- a/tests/resizeThrottle.test.js
+++ b/tests/resizeThrottle.test.js
@@ -1,0 +1,48 @@
+const { QuantumDashboard } = require('../app');
+
+describe('resize throttling', () => {
+  beforeEach(() => {
+    QuantumDashboard.prototype.init = jest.fn();
+  });
+
+  test('debounce waits before calling function', () => {
+    jest.useFakeTimers();
+    const dash = new QuantumDashboard();
+    const fn = jest.fn();
+    const debounced = dash.debounce(fn, 100);
+    debounced();
+    debounced();
+    jest.advanceTimersByTime(99);
+    expect(fn).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('resize and orientationchange use same handler', () => {
+    const listeners = {};
+    global.window = { addEventListener: jest.fn((evt, h) => { listeners[evt] = h; }), innerWidth: 800 };
+    global.document = {
+      getElementById: jest.fn(),
+      querySelectorAll: jest.fn(() => [])
+    };
+    const dash = new QuantumDashboard();
+    dash.setupEventListeners();
+    expect(listeners.resize).toBe(listeners.orientationchange);
+  });
+
+  test('orientationchange triggers debounced resize', () => {
+    jest.useFakeTimers();
+    const listeners = {};
+    global.window = { addEventListener: jest.fn((evt, h) => { listeners[evt] = h; }), innerWidth: 800 };
+    global.document = {
+      getElementById: jest.fn(),
+      querySelectorAll: jest.fn(() => [])
+    };
+    const dash = new QuantumDashboard();
+    dash.handleResize = jest.fn();
+    dash.setupEventListeners();
+    listeners.orientationchange();
+    jest.advanceTimersByTime(101);
+    expect(dash.handleResize).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- debounce resize handlers in app.js for better performance
- throttle orientationchange using same debounced handler
- add unit tests for debounce logic and handler sharing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887c3d454e08322ae8f89ef3feefa0e