### PR TITLE
Modularize chart configs

### DIFF
--- a/app.js
+++ b/app.js
@@ -261,100 +261,129 @@ class QuantumDashboard {
         }
     }
 
-    async createCharts() {
-        if (!this.data.market_projections.length) {
-            await this.loadDataFromCSVs();
-        }
+    /**
+     * Build configuration for the market growth line chart.
+     * @returns {Object} Chart.js configuration
+     */
+    getMarketChartConfig() {
+        const mp = this.data.market_projections;
+        return {
+            type: 'line',
+            data: {
+                labels: mp.map(d => d.year),
+                datasets: [
+                    { label: 'Conservative', borderColor: '#3b82f6', data: mp.map(d => d.conservative), fill: false },
+                    { label: 'Moderate', borderColor: '#10b981', data: mp.map(d => d.moderate), fill: false },
+                    { label: 'Aggressive', borderColor: '#ef4444', data: mp.map(d => d.aggressive), fill: false }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: { mode: 'nearest', intersect: false },
+                plugins: {
+                    tooltip: { enabled: true },
+                    legend: {
+                        display: true,
+                        onClick: (e, item, legend) => {
+                            const ci = legend.chart;
+                            ci.toggleDatasetVisibility(item.datasetIndex);
+                            ci.update();
+                        }
+                    }
+                }
+            }
+        };
+    }
 
+    /**
+     * Build configuration for the regional distribution doughnut chart.
+     * @returns {Object} Chart.js configuration
+     */
+    getRegionalChartConfig() {
+        const rd = this.data.regional_data;
+        return {
+            type: 'doughnut',
+            data: {
+                labels: rd.map(d => d.region),
+                datasets: [{ data: rd.map(d => d.share) }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { tooltip: { enabled: true }, legend: { display: true } }
+            }
+        };
+    }
+
+    /**
+     * Build configuration for the investment flows stacked bar chart.
+     * @returns {Object} Chart.js configuration
+     */
+    getInvestmentChartConfig() {
+        const flows = this.data.investment_flows;
+        return {
+            type: 'bar',
+            data: {
+                labels: flows.map(d => d.year),
+                datasets: [
+                    { label: 'VC', backgroundColor: '#3b82f6', data: flows.map(d => d.vc) },
+                    { label: 'Government', backgroundColor: '#10b981', data: flows.map(d => d.government) },
+                    { label: 'Corporate', backgroundColor: '#facc15', data: flows.map(d => d.corporate) }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: { x: { stacked: true }, y: { stacked: true } },
+                plugins: { tooltip: { enabled: true }, legend: { display: true } }
+            }
+        };
+    }
+
+    /**
+     * Build configuration for the company performance bubble chart.
+     * @returns {Object} Chart.js configuration
+     */
+    getCompanyChartConfig() {
         const techColors = {
             'Superconducting': '#3b82f6',
             'Trapped Ion': '#ef4444',
             'Topological': '#10b981',
             'Annealing': '#facc15'
         };
+        const comps = this.data.companies;
+        return {
+            type: 'bubble',
+            data: {
+                datasets: comps.map(c => ({
+                    label: c.name,
+                    backgroundColor: techColors[c.technology] || '#94a3b8',
+                    data: [{ x: c.marketCap || 0, y: c.revenue || 0, r: Math.sqrt(c.employees) / 20 }]
+                }))
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { tooltip: { enabled: true }, legend: { display: true } }
+            }
+        };
+    }
 
+    async createCharts() {
+        if (!this.data.market_projections.length) {
+            await this.loadDataFromCSVs();
+        }
         const marketCtx = document.getElementById('market-growth-chart');
         const regionalCtx = document.getElementById('regional-chart');
         const investCtx = document.getElementById('investment-chart');
         const companyCtx = document.getElementById('company-chart');
 
-        const mp = this.data.market_projections;
-        const rd = this.data.regional_data;
-        const flows = this.data.investment_flows;
-        const comps = this.data.companies;
-
         this.charts = {
-            market: new Chart(marketCtx, {
-                type: 'line',
-                data: {
-                    labels: mp.map(d => d.year),
-                    datasets: [
-                        { label: 'Conservative', borderColor: '#3b82f6', data: mp.map(d => d.conservative), fill: false },
-                        { label: 'Moderate', borderColor: '#10b981', data: mp.map(d => d.moderate), fill: false },
-                        { label: 'Aggressive', borderColor: '#ef4444', data: mp.map(d => d.aggressive), fill: false }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    interaction: { mode: 'nearest', intersect: false },
-                    plugins: {
-                        tooltip: { enabled: true },
-                        legend: {
-                            display: true,
-                            onClick: (e, item, legend) => {
-                                const ci = legend.chart;
-                                ci.toggleDatasetVisibility(item.datasetIndex);
-                                ci.update();
-                            }
-                        }
-                    }
-                }
-            }),
-            regional: new Chart(regionalCtx, {
-                type: 'doughnut',
-                data: {
-                    labels: rd.map(d => d.region),
-                    datasets: [{ data: rd.map(d => d.share) }]
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: { tooltip: { enabled: true }, legend: { display: true } }
-                }
-            }),
-            investment: new Chart(investCtx, {
-                type: 'bar',
-                data: {
-                    labels: flows.map(d => d.year),
-                    datasets: [
-                        { label: 'VC', backgroundColor: '#3b82f6', data: flows.map(d => d.vc) },
-                        { label: 'Government', backgroundColor: '#10b981', data: flows.map(d => d.government) },
-                        { label: 'Corporate', backgroundColor: '#facc15', data: flows.map(d => d.corporate) }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    scales: { x: { stacked: true }, y: { stacked: true } },
-                    plugins: { tooltip: { enabled: true }, legend: { display: true } }
-                }
-            }),
-            company: new Chart(companyCtx, {
-                type: 'bubble',
-                data: {
-                    datasets: comps.map(c => ({
-                        label: c.name,
-                        backgroundColor: techColors[c.technology] || '#94a3b8',
-                        data: [{ x: c.marketCap || 0, y: c.revenue || 0, r: Math.sqrt(c.employees) / 20 }]
-                    }))
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: { tooltip: { enabled: true }, legend: { display: true } }
-                }
-            })
+            market: new Chart(marketCtx, this.getMarketChartConfig()),
+            regional: new Chart(regionalCtx, this.getRegionalChartConfig()),
+            investment: new Chart(investCtx, this.getInvestmentChartConfig()),
+            company: new Chart(companyCtx, this.getCompanyChartConfig())
         };
     }
 

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -4,6 +4,36 @@ beforeEach(() => {
   QuantumDashboard.prototype.init = jest.fn();
 });
 
+describe('chart config helpers', () => {
+  test('getMarketChartConfig returns line chart config', () => {
+    const dash = new QuantumDashboard();
+    const cfg = dash.getMarketChartConfig();
+    expect(cfg.type).toBe('line');
+    expect(cfg.data.datasets.length).toBe(3);
+  });
+
+  test('getRegionalChartConfig returns doughnut chart config', () => {
+    const dash = new QuantumDashboard();
+    const cfg = dash.getRegionalChartConfig();
+    expect(cfg.type).toBe('doughnut');
+    expect(cfg.data.labels.length).toBeGreaterThan(0);
+  });
+
+  test('getInvestmentChartConfig returns stacked bar config', () => {
+    const dash = new QuantumDashboard();
+    const cfg = dash.getInvestmentChartConfig();
+    expect(cfg.type).toBe('bar');
+    expect(cfg.data.datasets.length).toBe(3);
+  });
+
+  test('getCompanyChartConfig returns bubble chart config', () => {
+    const dash = new QuantumDashboard();
+    const cfg = dash.getCompanyChartConfig();
+    expect(cfg.type).toBe('bubble');
+    expect(cfg.data.datasets.length).toBeGreaterThan(0);
+  });
+});
+
 describe('filterData', () => {
   test('filters by time range', () => {
     const dash = new QuantumDashboard();
@@ -76,6 +106,10 @@ describe('createCharts', () => {
 
   test('instantiates charts with existing data', async () => {
     const dash = new QuantumDashboard();
+    dash.getMarketChartConfig = jest.fn(() => ({}));
+    dash.getRegionalChartConfig = jest.fn(() => ({}));
+    dash.getInvestmentChartConfig = jest.fn(() => ({}));
+    dash.getCompanyChartConfig = jest.fn(() => ({}));
     dash.data.market_projections = [{ year: 2024, conservative: 1, moderate: 2, aggressive: 3 }];
     dash.data.regional_data = [{ region: 'A', share: 10 }];
     dash.data.investment_flows = [{ year: 2024, vc: 1, government: 2, corporate: 3 }];
@@ -83,6 +117,10 @@ describe('createCharts', () => {
     await dash.createCharts();
     expect(Chart).toHaveBeenCalledTimes(4);
     expect(dash.charts.market).toBeDefined();
+    expect(dash.getMarketChartConfig).toHaveBeenCalled();
+    expect(dash.getRegionalChartConfig).toHaveBeenCalled();
+    expect(dash.getInvestmentChartConfig).toHaveBeenCalled();
+    expect(dash.getCompanyChartConfig).toHaveBeenCalled();
   });
 
   test('loads data when arrays are empty', async () => {


### PR DESCRIPTION
## Summary
- modularize chart configurations into helper functions
- refactor `createCharts` to use the helpers
- test the new helpers and verify calls from `createCharts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887c4dd1adc83228980554d58d1ddfc